### PR TITLE
Feature: use munit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       - run: sbt ++${{ matrix.scala }} ci
 
       - name: Compress target directories
-        run: tar cf targets.tar target testkit/jvm/target project/target
+        run: tar cf targets.tar target testkit/jvm/target testkit/js/target project/target
 
       - name: Upload target directories
         uses: actions/upload-artifact@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # unreleased
 
-:warning: Breaking changes :warning:
+### :warning: Breaking changes :warning:
 
 - replace scalatest w/ [munit-cats-effect](https://github.com/typelevel/munit-cats-effect) `1.0.1`. Do not forget to add `testFrameworks += new TestFramework("munit.Framework")` to your build, as per [usage instructions](https://scalameta.org/munit/docs/getting-started.html)
 
-Add
+### Deprecations
+
+- `PureharmTestWithResource`. You can just use the `munit` style within the `PureharmTest`. Simply do:
+
+```scala
+import busymachines.pureharm.testkit._
+
+final class MyTest extends PureharmTest {
+  private val myResource =
+    ResourceFixture((to: TestOptions) => Resource.liftF(testLogger.info(s"Making: $to") >> Timer[IO].sleep(10.millis)))
+
+  myResource.test("with resource")((_: Unit) => testLogger.info("Executing test w/ resource"))
+}
+```
+
+### New Scala versions:
+
+- 3.0.0-RC1 for ScalaJS
 
 # 0.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # unreleased
 
+:warning: Breaking changes :warning:
+
+- replace scalatest w/ [munit-cats-effect](https://github.com/typelevel/munit-cats-effect) `1.0.1`. Do not forget to add `testFrameworks += new TestFramework("munit.Framework")` to your build, as per [usage instructions](https://scalameta.org/munit/docs/getting-started.html)
+
+Add
+
 # 0.1.0
 
 Split out from [pureharm](https://github.com/busymachines/pureharm) as of version `0.0.7`.
 
 :warning: Breaking changes :warning:
-- due to future plans to support scalajs, dependency on `org.typelevel %% "log4cats-slf4j"` was removed. And `TestLogger` now has to be provided in client code.
 
+- due to future plans to support scalajs, dependency on `org.typelevel %% "log4cats-slf4j"` was removed. And `TestLogger` now has to be provided in client code.

--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ val Scala3RC1 = "3.0.0-RC1"
 //see: https://github.com/xerial/sbt-sonatype#buildsbt
 ThisBuild / sonatypeCredentialHost := "s01.oss.sonatype.org"
 
-ThisBuild / baseVersion  := "0.1.0"
+ThisBuild / baseVersion  := "0.2"
 ThisBuild / organization := "com.busymachines"
 ThisBuild / organizationName := "BusyMachines"
 ThisBuild / homepage     := Option(url("https://github.com/busymachines/pureharm-testkit"))
@@ -70,7 +70,7 @@ ThisBuild / spiewakMainBranches       := List("main")
 ThisBuild / Test / publishArtifact    := false
 
 ThisBuild / scalaVersion       := Scala213
-ThisBuild / crossScalaVersions := List(Scala213, Scala3RC1)
+ThisBuild / crossScalaVersions := List(Scala213)
 
 //required for binary compat checks
 ThisBuild / versionIntroduced := Map(
@@ -84,10 +84,12 @@ ThisBuild / versionIntroduced := Map(
 ThisBuild / resolvers += Resolver.sonatypeRepo("releases")
 ThisBuild / resolvers += Resolver.sonatypeRepo("snapshots")
 
-val pureharmCoreV    = "0.1.0" //https://github.com/busymachines/pureharm-core/releases
-val pureharmEffectsV = "0.1.0" //https://github.com/busymachines/pureharm-effects-cats/releases
-val scalatestV       = "3.2.6" //https://github.com/scalatest/scalatest/releases
-val log4catsV        = "1.2.0" //https://github.com/typelevel/log4cats/releases
+// format: off
+val pureharmCoreV        = "0.1.0"     //https://github.com/busymachines/pureharm-core/releases
+val pureharmEffectsV     = "0.1.0"     //https://github.com/typelevel/cats-effect/releases
+val munitV               = "0.7.23"    //https://github.com/scalameta/munit/releases
+val log4catsV            = "1.2.0"     //https://github.com/typelevel/log4cats/releases
+// format: on
 //=============================================================================
 //============================== Project details ==============================
 //=============================================================================
@@ -102,18 +104,22 @@ lazy val root = project
   .enablePlugins(SonatypeCiReleasePlugin)
   .settings(commonSettings)
 
-lazy val testkit = crossProject(JVMPlatform)
+lazy val testkit = crossProject(JVMPlatform, JSPlatform)
   .settings(commonSettings)
   .settings(dottyJsSettings(ThisBuild / crossScalaVersions))
+  .jsSettings(
+    scalaJSLinkerConfig ~= (_.withModuleKind(ModuleKind.CommonJSModule))
+  )
   .settings(
     name := "pureharm-testkit",
     libraryDependencies ++= Seq(  
-      "com.busymachines" %%% "pureharm-core-anomaly" % pureharmCoreV withSources(),
-      "com.busymachines" %%% "pureharm-core-sprout" % pureharmCoreV withSources(),
-      "com.busymachines" %%% "pureharm-effects-cats" % pureharmEffectsV withSources(),
-      "org.typelevel" %%% "log4cats-core" % log4catsV withSources(),
-      
-     "org.scalatest" %%% "scalatest-funsuite" % scalatestV  withSources(),
+      // format: off
+      "com.busymachines" %%% "pureharm-core-anomaly"   % pureharmCoreV      withSources(),
+      "com.busymachines" %%% "pureharm-core-sprout"    % pureharmCoreV      withSources(),
+      "com.busymachines" %%% "pureharm-effects-cats"   % pureharmEffectsV   withSources(),
+      "org.typelevel"    %%% "log4cats-core"           % log4catsV          withSources(),
+      "org.scalameta"    %%% "munit"                   % munitV             withSources(),
+      // format: on
     ),
   )
 
@@ -129,6 +135,9 @@ lazy val testkitJVM = testkit.jvm.settings(
 //=============================================================================
 
 lazy val commonSettings = Seq(
+  //required for munit: https://scalameta.org/munit/docs/getting-started.html
+  testFrameworks += new TestFramework("munit.Framework"),
+
   Compile / unmanagedSourceDirectories ++= {
     val major = if (isDotty.value) "-3" else "-2"
     List(CrossType.Pure, CrossType.Full).flatMap(

--- a/build.sbt
+++ b/build.sbt
@@ -70,7 +70,7 @@ ThisBuild / spiewakMainBranches       := List("main")
 ThisBuild / Test / publishArtifact    := false
 
 ThisBuild / scalaVersion       := Scala213
-ThisBuild / crossScalaVersions := List(Scala213)
+ThisBuild / crossScalaVersions := List(Scala213, Scala3RC1)
 
 //required for binary compat checks
 ThisBuild / versionIntroduced := Map(
@@ -98,7 +98,7 @@ lazy val root = project
   .in(file("."))
   .aggregate(
     testkitJVM,
-    //testkitJS,
+    testkitJS,
   )
   .enablePlugins(NoPublishPlugin)
   .enablePlugins(SonatypeCiReleasePlugin)
@@ -106,10 +106,6 @@ lazy val root = project
 
 lazy val testkit = crossProject(JVMPlatform, JSPlatform)
   .settings(commonSettings)
-  .settings(dottyJsSettings(ThisBuild / crossScalaVersions))
-  .jsSettings(
-    scalaJSLinkerConfig ~= (_.withModuleKind(ModuleKind.CommonJSModule))
-  )
   .settings(
     name := "pureharm-testkit",
     libraryDependencies ++= Seq(  
@@ -127,8 +123,12 @@ lazy val testkitJVM = testkit.jvm.settings(
   javaOptions ++= Seq("-source", "1.8", "-target", "1.8")
 )
 
-//scalatest 3.2.6 not published yet for scalajs 3.0.0-RC1
-//lazy val testkitJS = testkit.js
+lazy val testkitJS = testkit
+  .settings(dottyJsSettings(ThisBuild / crossScalaVersions))
+  .jsSettings(
+    scalaJSLinkerConfig ~= (_.withModuleKind(ModuleKind.CommonJSModule))
+  )
+  .js
 
 //=============================================================================
 //================================= Settings ==================================

--- a/testkit/js/src/main/scala/busymachines/pureharm/testkit/util/PureharmTestPlatformSpecific.scala
+++ b/testkit/js/src/main/scala/busymachines/pureharm/testkit/util/PureharmTestPlatformSpecific.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 BusyMachines
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package busymachines.pureharm.testkit.util
+
+import busymachines.pureharm.effects._
+import busymachines.pureharm.effects.pools._
+
+trait PureharmTestPlatformSpecific {
+  protected def defaultExecutionContext: ExecutionContextCT = ExecutionContextCT(ExecutionContext.global)
+  protected def defaultFT:               ExecutionContextFT = ExecutionContextFT(ExecutionContext.global)
+}

--- a/testkit/jvm/src/main/scala/busymachines/pureharm/testkit/util/PureharmTestPlatformSpecific.scala
+++ b/testkit/jvm/src/main/scala/busymachines/pureharm/testkit/util/PureharmTestPlatformSpecific.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 BusyMachines
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package busymachines.pureharm.testkit.util
+
+import busymachines.pureharm.effects.pools._
+
+trait PureharmTestPlatformSpecific {
+  protected def defaultExecutionContext: ExecutionContextCT = _ecCT
+  protected def defaultFT:               ExecutionContextFT = _ecFT
+
+  private lazy val _ecCT = UnsafePools.cached("phtest-ec")
+  private lazy val _ecFT = UnsafePools.fixed("phtest-ft", 8)
+}

--- a/testkit/shared/src/main/scala/busymachines/pureharm/testkit/PureharmTestkitAliases.scala
+++ b/testkit/shared/src/main/scala/busymachines/pureharm/testkit/PureharmTestkitAliases.scala
@@ -14,9 +14,21 @@
  * limitations under the License.
  */
 
-package busymachines.pureharm
+package busymachines.pureharm.testkit
 
-/** @author Lorand Szakacs, https://github.com/lorandszakacs
-  * @since 26 Jun 2020
-  */
-package object testkit extends PureharmTestkitAliases
+trait PureharmTestkitAliases {
+  val Ignore: munit.Tag = munit.Ignore
+  val Only:   munit.Tag = munit.Only
+  val Flaky:  munit.Tag = munit.Flaky
+  val Fail:   munit.Tag = munit.Fail
+  val Slow:   munit.Tag = munit.Slow
+
+  type Location = munit.Location
+  val Location: munit.Location.type = munit.Location
+
+  type TestOptions = munit.TestOptions
+  val TestOptions: munit.TestOptions.type = munit.TestOptions
+
+  type TestLogger = types.TestLogger
+  val TestLogger: types.TestLogger.type = types.TestLogger
+}

--- a/testkit/shared/src/main/scala/busymachines/pureharm/testkit/types.scala
+++ b/testkit/shared/src/main/scala/busymachines/pureharm/testkit/types.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 BusyMachines
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package busymachines.pureharm.testkit
+
+import scala.annotation.implicitNotFound
+
+import busymachines.pureharm.effects._
+import busymachines.pureharm.sprout._
+import org.typelevel.log4cats._
+
+object types {
+
+  @implicitNotFound(
+    msg = """
+      |TestLogger should be available once you implement the abstract member in either:
+      |  - busymachines.pureharm.testkit.FixturePureharmTest
+      |  - busymachines.pureharm.testkit.PureharmTest
+      |
+      |The purpose of TestLogger is to log everything related to test-setup/
+      |tear-down to enrich whatever scalatest tells you
+      |"""
+  )
+  type TestLogger = TestLogger.Type
+  object TestLogger extends SproutSub[StructuredLogger[IO]]
+}

--- a/testkit/shared/src/main/scala/busymachines/pureharm/testkit/util/PureharmTestRuntime.scala
+++ b/testkit/shared/src/main/scala/busymachines/pureharm/testkit/util/PureharmTestRuntime.scala
@@ -21,16 +21,13 @@ import busymachines.pureharm.effects.pools._
 
 /** Usually overriding the "executionContext" should be enough
   */
-trait PureharmTestRuntime {
-
-  private lazy val defaultExecutionContext: ExecutionContextCT = UnsafePools.cached("phtest-ec")
-  private lazy val defaultFT:               ExecutionContextFT = UnsafePools.fixed("phtest-ft", 8)
+trait PureharmTestRuntime extends PureharmTestPlatformSpecific {
 
   private lazy val defaultContextShift: ContextShift[IO] = IO.contextShift(executionContextCT)
   private lazy val defaultTimer:        Timer[IO]        = IO.timer(executionContextCT)
 
   private lazy val defaultBlockingShifter: BlockingShifter[IO] =
-    BlockingShifter.fromExecutionContext(UnsafePools.cached("phtest-blocker"))
+    BlockingShifter.fromExecutionContext(defaultExecutionContext)
 
   def executionContextFT:          ExecutionContextFT  = defaultFT
   implicit def executionContextCT: ExecutionContextCT  = defaultExecutionContext

--- a/testkit/shared/src/main/scala/busymachines/pureharm/testkit/util/TestInitCatastrophe.scala
+++ b/testkit/shared/src/main/scala/busymachines/pureharm/testkit/util/TestInitCatastrophe.scala
@@ -14,9 +14,20 @@
  * limitations under the License.
  */
 
-package busymachines.pureharm
+package busymachines.pureharm.testkit.util
 
-/** @author Lorand Szakacs, https://github.com/lorandszakacs
-  * @since 26 Jun 2020
-  */
-package object testkit extends PureharmTestkitAliases
+import busymachines.pureharm.anomaly._
+import munit.TestOptions
+
+final case class TestInitCatastrophe(
+  override val message:  String,
+  options:  TestOptions,
+  override val causedBy: Option[Throwable] = Option.empty,
+) extends Catastrophe(message, causedBy) {
+
+  override def parameters: Anomaly.Parameters = super.parameters ++ Anomaly.Parameters(
+    "location" -> options.location.toString,
+    "tags"     -> options.tags.toSeq.map(_.toString()),
+    "testName" -> options.name,
+  )
+}

--- a/testkit/shared/src/main/scala/busymachines/pureharm/testkit/util/TestOutcome.scala
+++ b/testkit/shared/src/main/scala/busymachines/pureharm/testkit/util/TestOutcome.scala
@@ -14,9 +14,14 @@
  * limitations under the License.
  */
 
-package busymachines.pureharm
+package busymachines.pureharm.testkit.util
 
-/** @author Lorand Szakacs, https://github.com/lorandszakacs
-  * @since 26 Jun 2020
-  */
-package object testkit extends PureharmTestkitAliases
+sealed trait TestOutcome extends Product with Serializable {
+  override def toString: String = this.productPrefix
+}
+
+object TestOutcome {
+  case object Failed      extends TestOutcome
+  case object Succeeded   extends TestOutcome
+  case object InitError   extends TestOutcome
+}

--- a/testkit/shared/src/test/scala/busymachines/pureharm/testkit/PrintlnLogger.scala
+++ b/testkit/shared/src/test/scala/busymachines/pureharm/testkit/PrintlnLogger.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 BusyMachines
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package busymachines.pureharm.testkit
+
+import busymachines.pureharm.effects._
+
+object PrintlnLogger extends org.typelevel.log4cats.StructuredLogger[IO] {
+
+  private def p(s: String)(ctx: Map[String, String] = Map.empty): IO[Unit] =
+    if (ctx.isEmpty)
+      IO(println(s"-----> $s"))
+    else IO(println(s"-----> mdc=${ctx.mkString("[", ", ", "]")} -----> $s"))
+
+  def trace(ctx: Map[String, String])(msg: => String): IO[Unit] = p(msg)(ctx)
+  def trace(ctx: Map[String, String], t:   Throwable)(msg: => String): IO[Unit] = p(msg)(ctx)
+  def debug(ctx: Map[String, String])(msg: => String): IO[Unit] = p(msg)(ctx)
+  def debug(ctx: Map[String, String], t:   Throwable)(msg: => String): IO[Unit] = p(msg)(ctx)
+  def info(ctx:  Map[String, String])(msg: => String): IO[Unit] = p(msg)(ctx)
+  def info(ctx:  Map[String, String], t:   Throwable)(msg: => String): IO[Unit] = p(msg)(ctx)
+  def warn(ctx:  Map[String, String])(msg: => String): IO[Unit] = p(msg)(ctx)
+  def warn(ctx:  Map[String, String], t:   Throwable)(msg: => String): IO[Unit] = p(msg)(ctx)
+  def error(ctx: Map[String, String])(msg: => String): IO[Unit] = p(msg)(ctx)
+  def error(ctx: Map[String, String], t:   Throwable)(msg: => String): IO[Unit] = p(msg)(ctx)
+
+  def debug(t: Throwable)(message: => String): IO[Unit] = p(message)()
+  def error(t: Throwable)(message: => String): IO[Unit] = p(message)()
+  def info(t:  Throwable)(message: => String): IO[Unit] = p(message)()
+  def trace(t: Throwable)(message: => String): IO[Unit] = p(message)()
+  def warn(t:  Throwable)(message: => String): IO[Unit] = p(message)()
+
+  // Members declared in org.typelevel.log4cats.MessageLogger
+  def debug(message: => String): IO[Unit] = p(message)()
+  def error(message: => String): IO[Unit] = p(message)()
+  def info(message:  => String): IO[Unit] = p(message)()
+  def trace(message: => String): IO[Unit] = p(message)()
+  def warn(message:  => String): IO[Unit] = p(message)()
+
+}

--- a/testkit/shared/src/test/scala/busymachines/pureharm/testkit/PureharmTestTest.scala
+++ b/testkit/shared/src/test/scala/busymachines/pureharm/testkit/PureharmTestTest.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 BusyMachines
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package busymachines.pureharm.testkit
+
+import busymachines.pureharm.effects._
+import busymachines.pureharm.effects.implicits._
+import scala.concurrent.duration._
+
+final class PureharmTestTest extends PureharmTest {
+  implicit override val testLogger: TestLogger = TestLogger(PrintlnLogger)
+
+  val resource =
+    ResourceFixture((to: TestOptions) => Resource.liftF(testLogger.info(s"Making: $to") >> Timer[IO].sleep(10.millis)))
+
+  test("simple test") {
+    testLogger.info("Executing first test!")
+  }
+
+  resource.test("with resource") { _: Unit => testLogger.info("Executing test w/ resource") }
+
+  // test("throw exception in body") {
+  //   throw new RuntimeException("Comment me after running once")
+  // }
+
+  // test("invalid exception body") {
+  //   423
+  // }
+
+  // val failedResource = {
+  //   import busymachines.pureharm.anomaly.InvalidInputAnomaly
+  //   ResourceFixture((_: TestOptions) =>
+  //     Resource.eval(
+  //       Timer[IO].sleep(10.millis).flatMap(_ => InvalidInputAnomaly("failed resource").raiseError[IO, Unit])
+  //     )
+  //   )
+  // }
+
+  // failedResource.test("failed init")(_ => testLogger.info("never gonna used a failed resource"))
+}

--- a/testkit/shared/src/test/scala/busymachines/pureharm/testkit/PureharmTestTest.scala
+++ b/testkit/shared/src/test/scala/busymachines/pureharm/testkit/PureharmTestTest.scala
@@ -23,14 +23,14 @@ import scala.concurrent.duration._
 final class PureharmTestTest extends PureharmTest {
   implicit override val testLogger: TestLogger = TestLogger(PrintlnLogger)
 
-  val resource =
-    ResourceFixture((to: TestOptions) => Resource.liftF(testLogger.info(s"Making: $to") >> Timer[IO].sleep(10.millis)))
-
   test("simple test") {
     testLogger.info("Executing first test!")
   }
 
-  resource.test("with resource") { (_: Unit) => testLogger.info("Executing test w/ resource") }
+  private val myResource =
+    ResourceFixture((to: TestOptions) => Resource.liftF(testLogger.info(s"Making: $to") >> Timer[IO].sleep(10.millis)))
+
+  myResource.test("with resource")((_: Unit) => testLogger.info("Executing test w/ resource"))
 
   // test("throw exception in body") {
   //   throw new RuntimeException("Comment me after running once")

--- a/testkit/shared/src/test/scala/busymachines/pureharm/testkit/PureharmTestTest.scala
+++ b/testkit/shared/src/test/scala/busymachines/pureharm/testkit/PureharmTestTest.scala
@@ -30,7 +30,7 @@ final class PureharmTestTest extends PureharmTest {
     testLogger.info("Executing first test!")
   }
 
-  resource.test("with resource") { _: Unit => testLogger.info("Executing test w/ resource") }
+  resource.test("with resource") { (_: Unit) => testLogger.info("Executing test w/ resource") }
 
   // test("throw exception in body") {
   //   throw new RuntimeException("Comment me after running once")


### PR DESCRIPTION
Drop scalatest entirely. Replace w/ [munit](https://scalameta.org/munit/docs/getting-started.html).

The opiniated pureharm test style remains mostly source compatible. i.e. Write all your tests in `IO`. The custom assertions look the same. 

Deprecates `PureharmTestWithResource` in favor of the `munit.FixtureFun[T]` style. Implementation adapted from `munit-cats-effect`. Decided to depend only on `munit` because it was easier to add all the logging around tests like in previous `pureharm-testkit` releases, than it was adapting the existing `munit-cats-effect` implementation. Additionally, the assertions provided by `munit-cats-effect` did not fit the pureharm style.

Great plus: adds working ScalaJS build.